### PR TITLE
Fix typos and add unit test

### DIFF
--- a/tests/test_base_utils.py
+++ b/tests/test_base_utils.py
@@ -1,0 +1,51 @@
+import importlib
+import os
+import sys
+import types
+import numpy as np
+
+def load_base_utils():
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+    cv2_stub = types.ModuleType('cv2')
+    cv2_stub.createLineSegmentDetector = lambda *a, **k: None
+    cv2_stub.getStructuringElement = lambda *a, **k: None
+    cv2_stub.Canny = lambda *a, **k: None
+    cv2_stub.dilate = lambda *a, **k: None
+    cv2_stub.erode = lambda *a, **k: None
+    cv2_stub.adaptiveThreshold = lambda *a, **k: np.zeros((1,1), dtype=np.uint8)
+    cv2_stub.medianBlur = lambda img, size: img
+    cv2_stub.bitwise_and = lambda a, b: None
+    cv2_stub.add = lambda a, b: None
+    cv2_stub.boundingRect = lambda cnt: [0,0,1,1]
+    cv2_stub.boxPoints = lambda rect: np.array([[0,0],[1,0],[1,1],[0,1]])
+    cv2_stub.cvtColor = lambda img, code: img
+    cv2_stub.MORPH_RECT = cv2_stub.MORPH_OPEN = None
+    cv2_stub.morphologyEx = lambda *a, **k: None
+    sys.modules['cv2'] = cv2_stub
+
+    pymysql_stub = types.ModuleType('pymysql')
+    pymysql_stub.install_as_MySQLdb = lambda: None
+    sys.modules['pymysql'] = pymysql_stub
+
+    sqlalchemy_stub = types.ModuleType('sqlalchemy')
+    sqlalchemy_stub.create_engine = lambda *a, **k: None
+    sqlalchemy_stub.text = lambda x: x
+    sys.modules['sqlalchemy'] = sqlalchemy_stub
+
+    sqlalchemy_orm_stub = types.ModuleType('sqlalchemy.orm')
+    sqlalchemy_orm_stub.sessionmaker = lambda bind=None: lambda: None
+    sys.modules['sqlalchemy.orm'] = sqlalchemy_orm_stub
+
+    psutil_stub = types.ModuleType('psutil')
+    psutil_stub.Process = lambda pid: types.SimpleNamespace(memory_info=lambda: types.SimpleNamespace(rss=0, vms=0))
+    sys.modules['psutil'] = psutil_stub
+
+    if 'tools.base_utils' in sys.modules:
+        del sys.modules['tools.base_utils']
+    return importlib.import_module('tools.base_utils')
+
+def test_drop_duplicated_points():
+    base_utils = load_base_utils()
+    data = [4,5,6,7,8,9,10,1748,1749,1750,1751,1762,1763,1764,1765,1766,3504,3505,3506,3507,3508,3509]
+    expected = [10, 1751, 1766, 3509]
+    assert base_utils.drop_duplicated_points(data, max_span=10) == expected

--- a/tools/line_position.py
+++ b/tools/line_position.py
@@ -8,7 +8,7 @@ from base_utils import *
 
 
 
-def repire_y_nums(binary_z, y_scale, right_num, max_try_times=50):
+def repair_y_nums(binary_z, y_scale, right_num, max_try_times=50):
     '''
     根据制定的纵线数量选择参数 改进 可以用二分查找 或者
     @param binary_z:
@@ -30,7 +30,7 @@ def repire_y_nums(binary_z, y_scale, right_num, max_try_times=50):
         else:
             break
         if y_scale < 0 or y_scale > 50 or num > max_try_times:
-            print(5 / 0)
+            raise ValueError("Failed to locate correct line positions")
     return y_point_arr
 
 
@@ -105,7 +105,7 @@ def get_position_arr(binary_z, cols_list):
     x_point_arr, y_point_arr = get_table_coordinate(bitwise_and_z, max_span=25)  # 如果异常修改为10
 
     if len(x_point_arr) != right_num:
-        x_point_arr = repire_y_nums(binary_z, y_scale=20, right_num=right_num)
+        x_point_arr = repair_y_nums(binary_z, y_scale=20, right_num=right_num)
 
     return x_point_arr, y_point_arr
 

--- a/tools/table_area.py
+++ b/tools/table_area.py
@@ -122,14 +122,13 @@ def get_y_pos_by_line(rotated_binary):
 
 
 
-def get_table_area(file,gray):
+def get_table_area(file, gray):
     '''
+    Extract table regions from a gray image.
 
     :param file: 文件名称
     :param gray: 灰度图
-    :param table_split_implicit:表格类型
-    :param place_name: 地名
-    :return:
+    :return: 提取到的表格图像列表
     '''
 
     tables = get_table(gray)


### PR DESCRIPTION
## Summary
- rename `repire_y_nums` -> `repair_y_nums`
- raise `ValueError` instead of dividing by zero
- clarify `get_table_area` docstring
- add a unit test for `drop_duplicated_points`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68479c926f0c8324a575292f62eaabd3